### PR TITLE
feat: add TOEIC learning app focused on vocabulary and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# TOEIC Focus App
+
+Ứng dụng web đơn giản để học TOEIC, tập trung vào:
+
+- Học từ vựng theo flashcard.
+- Luyện câu hỏi ngữ pháp dạng trắc nghiệm.
+- Theo dõi tiến độ bằng điểm số lưu trên trình duyệt (localStorage).
+
+## Chạy ứng dụng
+
+Mở trực tiếp file `index.html` hoặc chạy server tĩnh:
+
+```bash
+python3 -m http.server 4173
+```
+
+Sau đó truy cập `http://localhost:4173`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,133 @@
+const vocabulary = [
+  { word: "achieve", meaning: "đạt được" },
+  { word: "appointment", meaning: "cuộc hẹn" },
+  { word: "negotiate", meaning: "đàm phán" },
+  { word: "deadline", meaning: "hạn chót" },
+  { word: "shipment", meaning: "lô hàng" },
+  { word: "revenue", meaning: "doanh thu" },
+  { word: "efficient", meaning: "hiệu quả" },
+  { word: "proposal", meaning: "đề xuất" }
+];
+
+const grammarQuestions = [
+  {
+    question: "If she ____ earlier, she would have caught the train.",
+    options: ["left", "had left", "has left", "would leave"],
+    answer: "had left",
+    explanation: "Câu điều kiện loại 3 dùng 'had + V3' ở mệnh đề if."
+  },
+  {
+    question: "The report must ____ before Friday.",
+    options: ["submit", "be submitted", "submitted", "be submit"],
+    answer: "be submitted",
+    explanation: "Sau 'must' và bị động: must be + V3."
+  },
+  {
+    question: "Neither the manager nor the staff ____ aware of the change.",
+    options: ["was", "were", "be", "been"],
+    answer: "were",
+    explanation: "Động từ hòa hợp với chủ ngữ gần nhất 'staff' (số nhiều)."
+  },
+  {
+    question: "By the time we arrived, the meeting ____.",
+    options: ["starts", "started", "had started", "has started"],
+    answer: "had started",
+    explanation: "Một hành động xảy ra trước một mốc quá khứ: quá khứ hoàn thành."
+  }
+];
+
+let vocabIndex = 0;
+let grammarIndex = 0;
+let knownWords = Number(localStorage.getItem("toeicKnownWords") || 0);
+let correctGrammar = Number(localStorage.getItem("toeicCorrectGrammar") || 0);
+let revealedMeaning = false;
+
+const vocabWordEl = document.getElementById("vocab-word");
+const vocabMeaningEl = document.getElementById("vocab-meaning");
+const vocabScoreEl = document.getElementById("vocab-score");
+const grammarScoreEl = document.getElementById("grammar-score");
+const grammarQuestionEl = document.getElementById("grammar-question");
+const grammarOptionsEl = document.getElementById("grammar-options");
+const grammarFeedbackEl = document.getElementById("grammar-feedback");
+
+function updateScores() {
+  vocabScoreEl.textContent = `${knownWords}/${vocabulary.length}`;
+  grammarScoreEl.textContent = `${correctGrammar}/${grammarQuestions.length}`;
+  localStorage.setItem("toeicKnownWords", String(knownWords));
+  localStorage.setItem("toeicCorrectGrammar", String(correctGrammar));
+}
+
+function renderWord() {
+  const currentWord = vocabulary[vocabIndex];
+  vocabWordEl.textContent = currentWord.word;
+  vocabMeaningEl.textContent = revealedMeaning ? currentWord.meaning : 'Nhấn "Hiện nghĩa" để xem.';
+}
+
+function nextWord() {
+  vocabIndex = (vocabIndex + 1) % vocabulary.length;
+  revealedMeaning = false;
+  renderWord();
+}
+
+function renderGrammarQuestion() {
+  const current = grammarQuestions[grammarIndex];
+  grammarQuestionEl.textContent = current.question;
+  grammarFeedbackEl.textContent = "";
+  grammarFeedbackEl.className = "feedback";
+  grammarOptionsEl.innerHTML = "";
+
+  current.options.forEach((option) => {
+    const btn = document.createElement("button");
+    btn.textContent = option;
+    btn.className = "option-btn";
+    btn.addEventListener("click", () => checkGrammarAnswer(option));
+    grammarOptionsEl.appendChild(btn);
+  });
+}
+
+function checkGrammarAnswer(selected) {
+  const current = grammarQuestions[grammarIndex];
+  const isCorrect = selected === current.answer;
+
+  if (isCorrect) {
+    grammarFeedbackEl.textContent = `✅ Chính xác! ${current.explanation}`;
+    grammarFeedbackEl.className = "feedback ok";
+    correctGrammar = Math.min(correctGrammar + 1, grammarQuestions.length);
+    updateScores();
+  } else {
+    grammarFeedbackEl.textContent = `❌ Chưa đúng. Đáp án: ${current.answer}. ${current.explanation}`;
+    grammarFeedbackEl.className = "feedback nope";
+  }
+}
+
+function nextGrammarQuestion() {
+  grammarIndex = (grammarIndex + 1) % grammarQuestions.length;
+  renderGrammarQuestion();
+}
+
+document.getElementById("show-meaning").addEventListener("click", () => {
+  revealedMeaning = true;
+  renderWord();
+});
+
+document.getElementById("mark-known").addEventListener("click", () => {
+  knownWords = Math.min(knownWords + 1, vocabulary.length);
+  updateScores();
+  nextWord();
+});
+
+document.getElementById("next-word").addEventListener("click", nextWord);
+document.getElementById("next-grammar").addEventListener("click", nextGrammarQuestion);
+
+document.querySelectorAll(".tab-btn").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    document.querySelectorAll(".tab-btn").forEach((item) => item.classList.remove("active"));
+    document.querySelectorAll(".tab-panel").forEach((panel) => panel.classList.remove("active"));
+    btn.classList.add("active");
+    document.getElementById(btn.dataset.tab).classList.add("active");
+  });
+});
+
+updateScores();
+renderWord();
+renderGrammarQuestion();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TOEIC Focus - Từ vựng & Ngữ pháp</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <h1>TOEIC Focus</h1>
+        <p>Ứng dụng học TOEIC tập trung vào <strong>từ vựng</strong> và <strong>ngữ pháp</strong>.</p>
+      </header>
+
+      <section class="stats" aria-label="Tiến độ học tập">
+        <article>
+          <h2 id="vocab-score">0/0</h2>
+          <p>Từ vựng đã nhớ</p>
+        </article>
+        <article>
+          <h2 id="grammar-score">0/0</h2>
+          <p>Ngữ pháp đúng</p>
+        </article>
+      </section>
+
+      <nav class="tabs" aria-label="Chọn chế độ học">
+        <button class="tab-btn active" data-tab="vocab">Học từ vựng</button>
+        <button class="tab-btn" data-tab="grammar">Luyện ngữ pháp</button>
+      </nav>
+
+      <section id="vocab" class="tab-panel active" aria-live="polite">
+        <div class="card" id="vocab-card">
+          <h3 id="vocab-word">Loading...</h3>
+          <p id="vocab-meaning">Nhấn "Hiện nghĩa" để xem.</p>
+          <div class="actions">
+            <button id="show-meaning">Hiện nghĩa</button>
+            <button id="mark-known" class="success">Đã thuộc</button>
+            <button id="next-word">Từ tiếp theo</button>
+          </div>
+        </div>
+      </section>
+
+      <section id="grammar" class="tab-panel" aria-live="polite">
+        <div class="card">
+          <h3 id="grammar-question">Loading...</h3>
+          <div id="grammar-options" class="options"></div>
+          <p id="grammar-feedback" class="feedback"></p>
+          <div class="actions">
+            <button id="next-grammar">Câu tiếp theo</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,151 @@
+:root {
+  --bg: #f4f6fb;
+  --card: #ffffff;
+  --primary: #284bce;
+  --text: #1b2430;
+  --muted: #5b6675;
+  --success: #1e9249;
+  --border: #dde3ee;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.container {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 24px 16px 40px;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.hero h1 {
+  margin-bottom: 8px;
+  color: var(--primary);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.stats article {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  text-align: center;
+}
+
+.stats h2 {
+  margin: 0;
+}
+
+.stats p {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.tab-btn {
+  border: 1px solid var(--border);
+  background: #fff;
+  border-radius: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.tab-btn.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 22px;
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+button {
+  border: 1px solid var(--border);
+  background: #fff;
+  padding: 10px 13px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+button.success {
+  background: #e8f8ef;
+  border-color: #bde7cc;
+  color: var(--success);
+}
+
+.options {
+  display: grid;
+  gap: 8px;
+}
+
+.option-btn {
+  text-align: left;
+}
+
+.feedback {
+  min-height: 26px;
+  margin-top: 12px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.feedback.ok {
+  color: var(--success);
+}
+
+.feedback.nope {
+  color: #b42318;
+}
+
+@media (max-width: 620px) {
+  .stats {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight static web app to help learners practice TOEIC vocabulary and grammar with quick interactions and progress tracking.
- Ship a minimal, responsive UI that works without backend so it can be opened directly or served from a static server.

### Description
- Add `index.html` that implements the UI with two study tabs (vocabulary flashcard and grammar multiple-choice) and score widgets. 
- Add `styles.css` for responsive visual styling, tab navigation and card components.
- Add `app.js` containing sample `vocabulary` and `grammarQuestions` data, rendering logic, interaction handlers, tab switching, and persistence using `localStorage` for progress.
- Add `README.md` with instructions to run the app locally via `python3 -m http.server`.

### Testing
- Ran `node --check app.js`, which succeeded. 
- Served the site with `python3 -m http.server 4173` and verified `curl -I http://127.0.0.1:4173` returned `HTTP/1.0 200 OK`. 
- Attempted a Playwright Chromium screenshot which failed with a `TargetClosedError`/SIGSEGV during browser launch, and then successfully captured a screenshot using Playwright with Firefox (artifact saved at `artifacts/toeic-focus-home.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ad303754832db78e84fa32b3eb02)