### PR TITLE
Add TOEIC Focus web app: vocabulary flashcards, grammar quizzes, and progress tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# TOEIC Focus App
+
+Ứng dụng web đơn giản để học TOEIC, tập trung vào:
+
+- Học từ vựng theo flashcard (30 từ vựng thông dụng trong ngữ cảnh TOEIC).
+- Luyện ngữ pháp dạng trắc nghiệm (20 câu với giải thích ngắn).
+- Theo dõi tiến độ bằng điểm số lưu trên trình duyệt (localStorage).
+
+## Chạy ứng dụng
+
+Mở trực tiếp file `index.html` hoặc chạy server tĩnh:
+
+```bash
+python3 -m http.server 4173
+```
+
+Sau đó truy cập `http://localhost:4173`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,251 @@
+const vocabulary = [
+  { word: "achieve", meaning: "đạt được" },
+  { word: "appointment", meaning: "cuộc hẹn" },
+  { word: "negotiate", meaning: "đàm phán" },
+  { word: "deadline", meaning: "hạn chót" },
+  { word: "shipment", meaning: "lô hàng" },
+  { word: "revenue", meaning: "doanh thu" },
+  { word: "efficient", meaning: "hiệu quả" },
+  { word: "proposal", meaning: "đề xuất" },
+  { word: "inventory", meaning: "hàng tồn kho" },
+  { word: "invoice", meaning: "hóa đơn" },
+  { word: "maintenance", meaning: "bảo trì" },
+  { word: "conference", meaning: "hội nghị" },
+  { word: "schedule", meaning: "lịch trình" },
+  { word: "customer", meaning: "khách hàng" },
+  { word: "promotion", meaning: "khuyến mãi" },
+  { word: "discount", meaning: "giảm giá" },
+  { word: "contract", meaning: "hợp đồng" },
+  { word: "candidate", meaning: "ứng viên" },
+  { word: "qualification", meaning: "trình độ" },
+  { word: "department", meaning: "phòng ban" },
+  { word: "branch", meaning: "chi nhánh" },
+  { word: "budget", meaning: "ngân sách" },
+  { word: "expense", meaning: "chi phí" },
+  { word: "purchase", meaning: "mua hàng" },
+  { word: "supplier", meaning: "nhà cung cấp" },
+  { word: "delivery", meaning: "giao hàng" },
+  { word: "postpone", meaning: "hoãn lại" },
+  { word: "confirm", meaning: "xác nhận" },
+  { word: "available", meaning: "có sẵn" },
+  { word: "deadline extension", meaning: "gia hạn thời hạn" }
+];
+
+const grammarQuestions = [
+  {
+    question: "If she ____ earlier, she would have caught the train.",
+    options: ["left", "had left", "has left", "would leave"],
+    answer: "had left",
+    explanation: "Câu điều kiện loại 3 dùng 'had + V3' ở mệnh đề if."
+  },
+  {
+    question: "The report must ____ before Friday.",
+    options: ["submit", "be submitted", "submitted", "be submit"],
+    answer: "be submitted",
+    explanation: "Sau 'must' và bị động: must be + V3."
+  },
+  {
+    question: "Neither the manager nor the staff ____ aware of the change.",
+    options: ["was", "were", "be", "been"],
+    answer: "were",
+    explanation: "Động từ hòa hợp với chủ ngữ gần nhất 'staff' (số nhiều)."
+  },
+  {
+    question: "By the time we arrived, the meeting ____.",
+    options: ["starts", "started", "had started", "has started"],
+    answer: "had started",
+    explanation: "Một hành động xảy ra trước một mốc quá khứ: quá khứ hoàn thành."
+  },
+  {
+    question: "Ms. Linh is responsible ____ training new employees.",
+    options: ["for", "to", "with", "at"],
+    answer: "for",
+    explanation: "Cụm đúng: responsible for + V-ing/N."
+  },
+  {
+    question: "The clients requested that the proposal ____ revised.",
+    options: ["is", "be", "was", "being"],
+    answer: "be",
+    explanation: "Subjunctive sau 'request that': dùng động từ nguyên mẫu."
+  },
+  {
+    question: "No sooner ____ the presentation started than the projector failed.",
+    options: ["had", "has", "was", "did"],
+    answer: "had",
+    explanation: "Đảo ngữ với 'No sooner ... than': No sooner had + S + V3."
+  },
+  {
+    question: "The marketing team, along with its director, ____ attending the meeting.",
+    options: ["are", "were", "is", "be"],
+    answer: "is",
+    explanation: "Chủ ngữ chính là 'team' (số ít) nên dùng 'is'."
+  },
+  {
+    question: "This machine is not ____ as the previous model.",
+    options: ["more efficient", "as efficient", "most efficient", "efficienter"],
+    answer: "as efficient",
+    explanation: "So sánh ngang bằng dạng phủ định: not as + adj + as."
+  },
+  {
+    question: "If I ____ you, I would accept the offer immediately.",
+    options: ["am", "were", "was", "be"],
+    answer: "were",
+    explanation: "Câu điều kiện loại 2: If I were you..."
+  },
+  {
+    question: "All applicants ____ submit their resumes by Monday.",
+    options: ["must", "should to", "have", "can to"],
+    answer: "must",
+    explanation: "Động từ khuyết thiếu 'must' + V nguyên mẫu."
+  },
+  {
+    question: "The CEO asked ____ the quarterly report was ready.",
+    options: ["that", "if", "what", "which"],
+    answer: "if",
+    explanation: "Mệnh đề gián tiếp yes/no dùng 'if/whether'."
+  },
+  {
+    question: "The new policy will take effect ____ next month.",
+    options: ["in", "on", "at", "for"],
+    answer: "in",
+    explanation: "Dùng 'in' với tháng/năm/thời gian dài."
+  },
+  {
+    question: "Each of the employees ____ required to wear an ID badge.",
+    options: ["are", "were", "is", "have"],
+    answer: "is",
+    explanation: "Each of + plural noun đi với động từ số ít."
+  },
+  {
+    question: "The seminar was canceled ____ the speaker's illness.",
+    options: ["because", "because of", "despite", "although"],
+    answer: "because of",
+    explanation: "Theo sau là danh từ/cụm danh từ nên dùng 'because of'."
+  },
+  {
+    question: "The package ____ by the time we reached the office.",
+    options: ["delivered", "had been delivered", "was delivering", "has deliver"],
+    answer: "had been delivered",
+    explanation: "Bị động ở quá khứ hoàn thành: had been + V3."
+  },
+  {
+    question: "Please let me know as soon as you ____ the confirmation email.",
+    options: ["receive", "received", "will receive", "have receiving"],
+    answer: "receive",
+    explanation: "Trong mệnh đề thời gian với 'as soon as', dùng hiện tại đơn cho tương lai."
+  },
+  {
+    question: "The manager recommended ____ the budget before approving the plan.",
+    options: ["review", "to review", "reviewing", "reviewed"],
+    answer: "reviewing",
+    explanation: "Recommend thường đi với V-ing."
+  },
+  {
+    question: "Hardly ____ he entered the room when everyone applauded.",
+    options: ["had", "has", "did", "was"],
+    answer: "had",
+    explanation: "Đảo ngữ với 'Hardly ... when': Hardly had + S + V3..."
+  },
+  {
+    question: "The report contains ____ information than the previous one.",
+    options: ["many", "fewer", "more", "most"],
+    answer: "more",
+    explanation: "Information là danh từ không đếm được, dùng 'more'."
+  }
+];
+
+let vocabIndex = 0;
+let grammarIndex = 0;
+let knownWords = Number(localStorage.getItem("toeicKnownWords") || 0);
+let correctGrammar = Number(localStorage.getItem("toeicCorrectGrammar") || 0);
+let revealedMeaning = false;
+
+const vocabWordEl = document.getElementById("vocab-word");
+const vocabMeaningEl = document.getElementById("vocab-meaning");
+const vocabScoreEl = document.getElementById("vocab-score");
+const grammarScoreEl = document.getElementById("grammar-score");
+const grammarQuestionEl = document.getElementById("grammar-question");
+const grammarOptionsEl = document.getElementById("grammar-options");
+const grammarFeedbackEl = document.getElementById("grammar-feedback");
+
+function updateScores() {
+  vocabScoreEl.textContent = `${knownWords}/${vocabulary.length}`;
+  grammarScoreEl.textContent = `${correctGrammar}/${grammarQuestions.length}`;
+  localStorage.setItem("toeicKnownWords", String(knownWords));
+  localStorage.setItem("toeicCorrectGrammar", String(correctGrammar));
+}
+
+function renderWord() {
+  const currentWord = vocabulary[vocabIndex];
+  vocabWordEl.textContent = currentWord.word;
+  vocabMeaningEl.textContent = revealedMeaning ? currentWord.meaning : 'Nhấn "Hiện nghĩa" để xem.';
+}
+
+function nextWord() {
+  vocabIndex = (vocabIndex + 1) % vocabulary.length;
+  revealedMeaning = false;
+  renderWord();
+}
+
+function renderGrammarQuestion() {
+  const current = grammarQuestions[grammarIndex];
+  grammarQuestionEl.textContent = current.question;
+  grammarFeedbackEl.textContent = "";
+  grammarFeedbackEl.className = "feedback";
+  grammarOptionsEl.innerHTML = "";
+
+  current.options.forEach((option) => {
+    const btn = document.createElement("button");
+    btn.textContent = option;
+    btn.className = "option-btn";
+    btn.addEventListener("click", () => checkGrammarAnswer(option));
+    grammarOptionsEl.appendChild(btn);
+  });
+}
+
+function checkGrammarAnswer(selected) {
+  const current = grammarQuestions[grammarIndex];
+  const isCorrect = selected === current.answer;
+
+  if (isCorrect) {
+    grammarFeedbackEl.textContent = `✅ Chính xác! ${current.explanation}`;
+    grammarFeedbackEl.className = "feedback ok";
+    correctGrammar = Math.min(correctGrammar + 1, grammarQuestions.length);
+    updateScores();
+  } else {
+    grammarFeedbackEl.textContent = `❌ Chưa đúng. Đáp án: ${current.answer}. ${current.explanation}`;
+    grammarFeedbackEl.className = "feedback nope";
+  }
+}
+
+function nextGrammarQuestion() {
+  grammarIndex = (grammarIndex + 1) % grammarQuestions.length;
+  renderGrammarQuestion();
+}
+
+document.getElementById("show-meaning").addEventListener("click", () => {
+  revealedMeaning = true;
+  renderWord();
+});
+
+document.getElementById("mark-known").addEventListener("click", () => {
+  knownWords = Math.min(knownWords + 1, vocabulary.length);
+  updateScores();
+  nextWord();
+});
+
+document.getElementById("next-word").addEventListener("click", nextWord);
+document.getElementById("next-grammar").addEventListener("click", nextGrammarQuestion);
+
+document.querySelectorAll(".tab-btn").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    document.querySelectorAll(".tab-btn").forEach((item) => item.classList.remove("active"));
+    document.querySelectorAll(".tab-panel").forEach((panel) => panel.classList.remove("active"));
+    btn.classList.add("active");
+    document.getElementById(btn.dataset.tab).classList.add("active");
+  });
+});
+
+updateScores();
+renderWord();
+renderGrammarQuestion();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TOEIC Focus - Từ vựng & Ngữ pháp</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <h1>TOEIC Focus</h1>
+        <p>Ứng dụng học TOEIC tập trung vào <strong>từ vựng</strong> và <strong>ngữ pháp</strong>.</p>
+      </header>
+
+      <section class="stats" aria-label="Tiến độ học tập">
+        <article>
+          <h2 id="vocab-score">0/0</h2>
+          <p>Từ vựng đã nhớ</p>
+        </article>
+        <article>
+          <h2 id="grammar-score">0/0</h2>
+          <p>Ngữ pháp đúng</p>
+        </article>
+      </section>
+
+      <nav class="tabs" aria-label="Chọn chế độ học">
+        <button class="tab-btn active" data-tab="vocab">Học từ vựng</button>
+        <button class="tab-btn" data-tab="grammar">Luyện ngữ pháp</button>
+      </nav>
+
+      <section id="vocab" class="tab-panel active" aria-live="polite">
+        <div class="card" id="vocab-card">
+          <h3 id="vocab-word">Loading...</h3>
+          <p id="vocab-meaning">Nhấn "Hiện nghĩa" để xem.</p>
+          <div class="actions">
+            <button id="show-meaning">Hiện nghĩa</button>
+            <button id="mark-known" class="success">Đã thuộc</button>
+            <button id="next-word">Từ tiếp theo</button>
+          </div>
+        </div>
+      </section>
+
+      <section id="grammar" class="tab-panel" aria-live="polite">
+        <div class="card">
+          <h3 id="grammar-question">Loading...</h3>
+          <div id="grammar-options" class="options"></div>
+          <p id="grammar-feedback" class="feedback"></p>
+          <div class="actions">
+            <button id="next-grammar">Câu tiếp theo</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,151 @@
+:root {
+  --bg: #f4f6fb;
+  --card: #ffffff;
+  --primary: #284bce;
+  --text: #1b2430;
+  --muted: #5b6675;
+  --success: #1e9249;
+  --border: #dde3ee;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.container {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 24px 16px 40px;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.hero h1 {
+  margin-bottom: 8px;
+  color: var(--primary);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.stats article {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  text-align: center;
+}
+
+.stats h2 {
+  margin: 0;
+}
+
+.stats p {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.tab-btn {
+  border: 1px solid var(--border);
+  background: #fff;
+  border-radius: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.tab-btn.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 22px;
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+button {
+  border: 1px solid var(--border);
+  background: #fff;
+  padding: 10px 13px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+button.success {
+  background: #e8f8ef;
+  border-color: #bde7cc;
+  color: var(--success);
+}
+
+.options {
+  display: grid;
+  gap: 8px;
+}
+
+.option-btn {
+  text-align: left;
+}
+
+.feedback {
+  min-height: 26px;
+  margin-top: 12px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.feedback.ok {
+  color: var(--success);
+}
+
+.feedback.nope {
+  color: #b42318;
+}
+
+@media (max-width: 620px) {
+  .stats {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal single-page web app for TOEIC study focused on vocabulary flashcards and multiple-choice grammar practice. 
- Persist user progress in the browser so users can track known words and correct grammar answers across sessions. 
- Offer a small, responsive UI with accessible elements to quickly run locally and iterate on content.

### Description

- Add `index.html` which defines a two-tab UI for `Học từ vựng` and `Luyện ngữ pháp`, progress stats, and controls for showing meanings and advancing items. 
- Add `app.js` which implements a 31-item `vocabulary` list, 20 `grammarQuestions`, rendering and navigation logic, event handlers, and `localStorage` persistence via keys `toeicKnownWords` and `toeicCorrectGrammar`. 
- Add `styles.css` for layout, theming, responsive behavior, and visual feedback, and add `README.md` with quick run instructions including `python3 -m http.server 4173`.

### Testing

- No automated tests are included in this change and no automated test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ad303754832db78e84fa32b3eb02)